### PR TITLE
changed DeRecStatusNotification to DeRecSharerNotification (#41 fix)

### DIFF
--- a/src/main/java/org/derecalliance/derec/api/DeRecSharer.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecSharer.java
@@ -129,10 +129,10 @@ public interface DeRecSharer {
      * Note: More than one listener may be provided by composition such as:
      * <p>
      * <pre>{@code
-     * Consumer<DeRecStatusNotification> listener1 = n -> log(n.getType().name());
-     * Consumer<DeRecStatusNotification> listener2 = n -> {if (n.getSeverity().equals(ERROR)) alert(n.getType().name());};
+     * Consumer<DeRecSharerNotification> listener1 = n -> log(n.getType().name());
+     * Consumer<DeRecSharerNotification> listener2 = n -> {if (n.getSeverity().equals(ERROR)) alert(n.getType().name());};
      * sharer.setListener(listener1.andThen(listener2));
      * }</pre>
      */
-    void setListener(Consumer<DeRecStatusNotification> listener);
+    void setListener(Consumer<DeRecSharerNotification> listener);
 }

--- a/src/main/java/org/derecalliance/derec/api/DeRecSharerNotification.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecSharerNotification.java
@@ -19,13 +19,13 @@ package org.derecalliance.derec.api;
 
 import java.util.Optional;
 
-import static org.derecalliance.derec.api.DeRecStatusNotification.NotificationSeverity.*;
+import static org.derecalliance.derec.api.DeRecSharerNotification.NotificationSeverity.*;
 
 /**
  * A status notification may be emitted by a secret asynchronously to alert
  * an API user of changes to the status of the Secret
  */
-public interface DeRecStatusNotification {
+public interface DeRecSharerNotification {
 
     enum NotificationSeverity {UNCLASSIFIED, NORMAL, WARNING, ERROR}
 


### PR DESCRIPTION
- Fixes issue #41 by renaming interface DeRecStatusNotification to DeRecSharerNotification, and updating all related usages/imports