### PR TITLE
DeRecHelper updates

### DIFF
--- a/src/main/java/org/derecalliance/derec/api/DeRecHelper.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecHelper.java
@@ -32,21 +32,6 @@ import java.util.function.Function;
  * The API makes no assumptions about threading models or message passing models.
  */
 public interface DeRecHelper {
-
-	/**
-	 * Representation of a sharer as perceived by a helper in respect of a particular share
-	 */
-	interface SharerStatus extends DeRecPairingStatus {
-		DeRecIdentity getId();
-
-		/**
-		 * Returns whether the sharer is in recovery mode
-		 *
-		 * @return true if sharer is in recovery mode, false otherwise
-		 */
-		boolean isRecovering();
-	}
-
 	/**
 	 * Representation of a "share" at a helper. The helper knows nothing about a share other than that it is some
 	 * binary content stored by the library (which the app has no access to) which is identified by a sharer id and
@@ -60,7 +45,7 @@ public interface DeRecHelper {
 		/**
 		 * The sharer that this share belongs to
 		 */
-		SharerStatus getSharer();
+		DeRecSharerStatus getSharer();
 
 		/**
 		 * This share's secret id
@@ -163,21 +148,21 @@ public interface DeRecHelper {
 	 * @param sharerStatus sharer
 	 * @return a list of secret ids
 	 */
-	List<? extends DeRecSecret.Id> getSecretIds(SharerStatus sharerStatus);
+	List<? extends DeRecSecret.Id> getSecretIds(DeRecSharerStatus sharerStatus);
   
 	/**
 	 * Get a list of all sharers that this helper is helping
 	 *
 	 * @return list of sharers
 	 */
-	List<? extends SharerStatus> getSharers();
+	List<? extends DeRecSharerStatus> getSharers();
 
 	/**
 	 * Remove a sharer (identified by SharerStatus) as seen by this helper
 	 *
 	 * @param sharerStatus sharer to remove
 	 */
-	void removeSharer(SharerStatus sharerStatus);
+	void removeSharer(DeRecSharerStatus sharerStatus);
 
 	/**
 	 * Provide a "listener" for status and lifecycle event notifications relating to this helper's information,

--- a/src/main/java/org/derecalliance/derec/api/DeRecHelper.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecHelper.java
@@ -32,42 +32,6 @@ import java.util.function.Function;
  * The API makes no assumptions about threading models or message passing models.
  */
 public interface DeRecHelper {
-	/**
-	 * Representation of a "share" at a helper. The helper knows nothing about a share other than that it is some
-	 * binary content stored by the library (which the app has no access to) which is identified by a sharer id and
-	 * a secret id local to that sharer id. The app also has access to the version numbers kept by the library. This
-	 * may be useful for diagnostic purposes.
-	 * <p>
-	 * An app may remove a share, which has the effect of getting the library to mark the share as inactive and at
-	 * the next opportunity (on receipt of the next communication from the sharer) to request unpairing.
-	 */
-	interface Share {
-		/**
-		 * The sharer that this share belongs to
-		 */
-		DeRecSharerStatus getSharer();
-
-		/**
-		 * This share's secret id
-		 */
-		DeRecSecret.Id getSecretId();
-
-		/**
-		 * A list of versions currently held by the library
-		 */
-		List<Integer> getVersions();
-
-		/**
-		 * request removal of a share meaning make the share inactive and at the next opportunity, unpair from
-		 * the sharer for this secret.
-		 * The sharer's status becomes {@link DeRecHelperStatus.PairingStatus#PENDING_REMOVAL} until
-		 * the unpair request has been signalled to the sharer.
-		 * @return true if request has been carried out successfully, false if it has already been requested
-		 * or if the share is not known (possibly as a result of having previously been removed)
-		 */
-		boolean remove();
-	}
-
 	interface Notification {
 		Type getType(); // the type of the notification
 		DeRecIdentity getSharerId(); // the sharer id
@@ -97,7 +61,7 @@ public interface DeRecHelper {
 	interface NotificationResponse {
 		/**
 		 * Set to true if the helper wishes to refuse the request and discontinue the helper relationship. The
-		 * semantics are as though {@link Share#remove()} had been called.
+		 * semantics are as though {@link DeRecShare#remove()} had been called.
 		 */
 		boolean getUnpairPlease();
 
@@ -132,7 +96,7 @@ public interface DeRecHelper {
 	 *
 	 * @return a list (empty if no items a known)
 	 */
-	List<? extends DeRecHelper.Share> getShares();
+	List<? extends DeRecShare> getShares();
 
 	/**
 	 * Get a list of all version numbers stored by this helper for a given secret id

--- a/src/main/java/org/derecalliance/derec/api/DeRecHelper.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecHelper.java
@@ -32,32 +32,6 @@ import java.util.function.Function;
  * The API makes no assumptions about threading models or message passing models.
  */
 public interface DeRecHelper {
-	interface Notification {
-		Type getType(); // the type of the notification
-		DeRecIdentity getSharerId(); // the sharer id
-		DeRecSecret.Id getSecretId(); // the secretId or null if none
-		int getVersion(); // the version number or -1 if inapplicable
-
-
-		/**
-		 * The type of the notification - allows for introduction of custom helper notifications
-		 * aside from {@link StandardHelperNotificationType}
-		 */
-		interface Type {
-			String name();
-		}
-
-		enum StandardHelperNotificationType implements Type {
-			PAIR_INDICATION, // someone is trying to pair for a particular secret
-			UNPAIR_INDICATION, // someone is unpairing for a particular secret
-			UPDATE_INDICATION, // an update has been received for a secret
-			VERIFY_INDICATION, // a verification request has been received for a secret
-			LIST_SECRETS_INDICATION, // a request to list secrets has been received
-			RECOVER_SECRET_INDICATION // a request to recover a secret has been received
-		}
-	}
-
-
 	interface NotificationResponse {
 		/**
 		 * Set to true if the helper wishes to refuse the request and discontinue the helper relationship. The
@@ -137,5 +111,5 @@ public interface DeRecHelper {
 	 * Note: More than one listener may be provided by composition such as:
 	 * <p>
 	 */
-	void setListener(Function<Notification, NotificationResponse> listener);
+	void setListener(Function<DeRecHelperNotification, NotificationResponse> listener);
 }

--- a/src/main/java/org/derecalliance/derec/api/DeRecHelperNotification.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecHelperNotification.java
@@ -1,0 +1,31 @@
+package org.derecalliance.derec.api;
+
+/**
+ * Notifications related to the helper
+ */
+public interface DeRecHelperNotification {
+    Type getType(); // the type of the notification
+
+    DeRecIdentity getSharerId(); // the sharer id
+
+    DeRecSecret.Id getSecretId(); // the secretId or null if none
+
+    int getVersion(); // the version number or -1 if inapplicable
+
+    /**
+     * The type of the notification - allows for introduction of custom helper notifications
+     * aside from {@link StandardHelperNotificationType}
+     */
+    interface Type {
+        String name();
+    }
+
+    enum StandardHelperNotificationType implements Type {
+        PAIR_INDICATION, // someone is trying to pair for a particular secret
+        UNPAIR_INDICATION, // someone is unpairing for a particular secret
+        UPDATE_INDICATION, // an update has been received for a secret
+        VERIFY_INDICATION, // a verification request has been received for a secret
+        LIST_SECRETS_INDICATION, // a request to list secrets has been received
+        RECOVER_SECRET_INDICATION // a request to recover a secret has been received
+    }
+}

--- a/src/main/java/org/derecalliance/derec/api/DeRecShare.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecShare.java
@@ -1,0 +1,38 @@
+package org.derecalliance.derec.api;
+
+import java.util.List;
+
+/**
+ * Representation of a "share". The helper knows nothing about a share other than that it is some
+ * binary content stored by the library (which the app has no access to) which is identified by a sharer id and
+ * a secret id local to that sharer id. The app also has access to the version numbers kept by the library.
+ * <p>
+ * An app may remove a share, which has the effect of getting the library to mark the share as inactive and at
+ * the next opportunity (on receipt of the next communication from the sharer) to request unpairing.
+ */
+public interface DeRecShare {
+    /**
+     * The sharer that this share belongs to
+     */
+    DeRecSharerStatus getSharer();
+
+    /**
+     * This share's secret id
+     */
+    DeRecSecret.Id getSecretId();
+
+    /**
+     * A list of versions currently held by the library
+     */
+    List<Integer> getVersions();
+
+    /**
+     * request removal of a share meaning make the share inactive and at the next opportunity, unpair from
+     * the sharer for this secret.
+     * The sharer's status becomes {@link DeRecHelperStatus.PairingStatus#PENDING_REMOVAL} until
+     * the unpair request has been signalled to the sharer.
+     * @return true if request has been carried out successfully, false if it has already been requested
+     * or if the share is not known (possibly as a result of having previously been removed)
+     */
+    boolean remove();
+}

--- a/src/main/java/org/derecalliance/derec/api/DeRecSharerStatus.java
+++ b/src/main/java/org/derecalliance/derec/api/DeRecSharerStatus.java
@@ -1,0 +1,16 @@
+package org.derecalliance.derec.api;
+
+
+/**
+ * Representation of a sharer as perceived by a helper
+ */
+interface DeRecSharerStatus extends DeRecPairingStatus {
+    DeRecIdentity getId();
+
+    /**
+     * Returns whether the sharer is in recovery mode
+     *
+     * @return true if sharer is in recovery mode, false otherwise
+     */
+    boolean isRecovering();
+}


### PR DESCRIPTION
- Fixes issue #38 by separating SharerStatus to its own file DeRecSharerStatus.java
- Fixes issue #39 by separating interface Share to its own file DeRecShare.java
- Fixes issue #40 by separating interface Notification to its own file DeRecSharerHelperNotification.java